### PR TITLE
Broke some necessary code, but fixed fatal server exception.

### DIFF
--- a/src/main/java/com/jerry/meklm/common/tile/TileEntityMidChemicalTank.java
+++ b/src/main/java/com/jerry/meklm/common/tile/TileEntityMidChemicalTank.java
@@ -3,8 +3,6 @@ package com.jerry.meklm.common.tile;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.block.attribute.Attribute;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.capabilities.resolver.manager.ChemicalHandlerManager;
-import mekanism.common.tile.base.TileEntityMekanism;
 import mekanism.common.util.WorldUtils;
 
 import net.minecraft.core.BlockPos;
@@ -20,8 +18,6 @@ import com.jerry.meklm.common.capabilities.chemical.LargeChemicalTankChemicalTan
 import com.jerry.meklm.common.tier.MidChemicalTankTier;
 import com.jerry.meklm.common.tile.prefab.TileEntityLargeChemicalTank;
 import org.jetbrains.annotations.NotNull;
-
-import java.lang.reflect.Field;
 
 public class TileEntityMidChemicalTank extends TileEntityLargeChemicalTank<MidChemicalTankTier> {
 
@@ -45,7 +41,7 @@ public class TileEntityMidChemicalTank extends TileEntityLargeChemicalTank<MidCh
 
     @Override
     public @NotNull <T> LazyOptional<T> getOffsetCapabilityIfEnabled(@NotNull Capability<T> capability, Direction side, @NotNull Vec3i offset) {
-        Field gasField, infusionField, pigmentField, slurryField;
+    /*        Field gasField, infusionField, pigmentField, slurryField;
         try {
             gasField = TileEntityMekanism.class.getDeclaredField("gasHandlerManager");
             gasField.setAccessible(true);
@@ -69,8 +65,16 @@ public class TileEntityMidChemicalTank extends TileEntityLargeChemicalTank<MidCh
         }
         if (capability == ForgeCapabilities.ITEM_HANDLER) {
             return itemHandlerManager.resolve(capability, side);
-        }
+        }*/
         return getCapability(capability, side);
+        /*
+
+        if (capability == Capabilities.GAS_HANDLER) {
+            return Objects.requireNonNull(ChemicalHandlerManager, "Expected to have chemical handler").resolve(capability, side);
+        } else if (capability == Capabilities.ITEM.block()) {
+            return Objects.requireNonNull(itemHandlerManager, "Expected to have item handler").resolve(capability, side);
+        }
+        return WorldUtils.getCapability(level, capability, worldPosition, null, this, side);*/
     }
 
     @Override


### PR DESCRIPTION
## What / 目的
QUICKFIX: Removed reflection-based lines of code connected with `TileEntityMekanism` in `getOffsetCapabilityIfEnabled` in `TileEntityMidChemicalTank`. Why? To fix fatal server exception, connected with reflecting class `TileEntityMekanism`, what contains client-only references (class `net/minecraft/client/resources/sounds/SoundInstance` to be exact).

## Implementation Details / 实现细节
I just removed lines of code, which used reflection on `TileEntityMekanism` class and get exception fixed. You probably might asknowledge that change, because it breaks a bit behavior of linking gas pipes to the chemical tank.   

## Outcome / 结果
As the result - server exception fixed, everything works as it should be. I don't really think that this is a real fix, but a quickfix.
That, of course, changed behavior of chemical tank. Now there's no way to configure tank sides anymore, but no server crash, cool, right?)) And now there is only one side to operate with containings of that tank (like what mekanism manually sets), you can input/output something in/out that tank only from one operatable side.

## Additional Information / 附加信息
In that section I'll show exception stacktrace itself:
```
java.lang.RuntimeException: Attempted to load class net/minecraft/client/resources/sounds/SoundInstance for invalid dist DEDICATED_SERVER
	at net.minecraftforge.fml.loading.RuntimeDistCleaner.processClassWithFlags(RuntimeDistCleaner.java:57) ~[fmlloader-1.20.1-47.4.13.jar%2369!/:1.0] {}
	at cpw.mods.modlauncher.LaunchPluginHandler.offerClassNodeToPlugins(LaunchPluginHandler.java:88) ~[modlauncher-10.0.9.jar%2355!/:?] {}
	at cpw.mods.modlauncher.ClassTransformer.transform(ClassTransformer.java:120) ~[modlauncher-10.0.9.jar%2355!/:?] {}
	at cpw.mods.modlauncher.TransformingClassLoader.maybeTransformClassBytes(TransformingClassLoader.java:50) ~[modlauncher-10.0.9.jar%2355!/:?] {}
	at cpw.mods.cl.ModuleClassLoader.readerToClass(ModuleClassLoader.java:113) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.lambda$findClass$15(ModuleClassLoader.java:219) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.loadFromModule(ModuleClassLoader.java:229) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.findClass(ModuleClassLoader.java:219) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.loadClass(ModuleClassLoader.java:135) ~[securejarhandler-2.1.10.jar:?] {}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?] {}
	at java.lang.Class.getDeclaredFields0(Native Method) ~[?:?] {re:mixin}
	at java.lang.Class.privateGetDeclaredFields(Class.java:3473) ~[?:?] {re:mixin}
	at java.lang.Class.getDeclaredField(Class.java:2780) ~[?:?] {re:mixin}
	at com.jerry.meklm.common.tile.TileEntityMidChemicalTank.getOffsetCapabilityIfEnabled(TileEntityMidChemicalTank.java:50) ~[mekmm-1.20.1-1.1.0.jar%23203!/:1.1.0] {re:classloading}
	at mekanism.common.capabilities.IOffsetCapability.getOffsetCapability(IOffsetCapability.java:37) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.tile.TileEntityBoundingBlock.getCapability(TileEntityBoundingBlock.java:86) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.util.CapabilityUtils.getCapability(CapabilityUtils.java:21) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.lib.transmitter.acceptor.BoxedChemicalAcceptorCache.isChemicalAcceptorAndListen(BoxedChemicalAcceptorCache.java:60) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.content.network.transmitter.BoxedPressurizedTube.isValidAcceptor(BoxedPressurizedTube.java:220) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.content.network.transmitter.Transmitter.getPossibleAcceptorConnections(Transmitter.java:321) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.content.network.transmitter.BufferedTransmitter.requestsUpdate(BufferedTransmitter.java:69) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?] {re:mixin}
	at mekanism.common.lib.transmitter.DynamicNetwork.commit(DynamicNetwork.java:69) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.lib.transmitter.TransmitterNetworkRegistry.commitChanges(TransmitterNetworkRegistry.java:253) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.lib.transmitter.TransmitterNetworkRegistry.onTick(TransmitterNetworkRegistry.java:140) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading}
	at mekanism.common.lib.transmitter.__TransmitterNetworkRegistry_onTick_ServerTickEvent.invoke(.dynamic) ~[Mekanism-1.20.1-10.4.16.80.jar%23200!/:10.4.16] {re:classloading,pl:eventbus:B}
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:73) ~[eventbus-6.0.5.jar%2352!/:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:315) ~[eventbus-6.0.5.jar%2352!/:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:296) ~[eventbus-6.0.5.jar%2352!/:?] {}
	at net.minecraftforge.event.ForgeEventFactory.onPostServerTick(ForgeEventFactory.java:975) ~[forge-1.20.1-47.4.13-universal.jar%23224!/:?] {re:classloading}
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:835) ~[server-1.20.1-20230612.114412-srg.jar%23219!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661) ~[server-1.20.1-20230612.114412-srg.jar%23219!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251) ~[server-1.20.1-20230612.114412-srg.jar%23219!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at java.lang.Thread.run(Thread.java:1583) ~[?:?] {re:mixin}
``` 
That's how i found that reflection attempts btw. 

And also I'll leave some additional information, what I got by checks:
1. That exception occurs only on server side.
2. Happens when trying to connect gas pipe to the tank
3. Leads to a complete server crush - I see no option to fix that.
4. Behavior of the tank is strange even in singleplayer (connection to sides of the tank somehow can break)

Minecraft version: 1.20.1
Mod version: 1.1.0

## Potential Compatibility Issues / 潜在兼容性问题
I assume some back-compatibility issues for singleplayer worlds, something with that tank and connected pipes may behave wrong. 

Sorry that I cannot provide more additional information, i didn't left issue cos it's basically.. you know.. quickfix)) and i didn't want to bother you with that old forge API and 1.20.1 issues. If you want - you can examine that problem further, but now thats where I ended up. And sorry for maybe stupid desicion, I am not a Java developer, and don't even developed any mods, I'm just a server maintainer. 

I didn't quite tested that in all situations, I made server start, and now I just need some sleep, it's already half past three,,,