### PR TITLE
Decouple nutrient solution cost from processing time

### DIFF
--- a/src/main/java/com/jerry/datagen/common/recipe/imp/PlantingRecipeProvider.java
+++ b/src/main/java/com/jerry/datagen/common/recipe/imp/PlantingRecipeProvider.java
@@ -18,6 +18,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class PlantingRecipeProvider implements ISubRecipeProvider {
 
+    /**
+     * Amount of Nutrient Solution (in mB) required per recipe tick.
+     * Reduce this value to lower the nutrient cost for all planting recipes.
+     */
+    public static final long NUTRIENT_COST_PER_TICK = 1L;
+
     @Override
     public void addRecipes(RecipeOutput consumer, HolderLookup.Provider registries) {
         String basePath = "planting/";
@@ -25,49 +31,49 @@ public class PlantingRecipeProvider implements ISubRecipeProvider {
         // Oak
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.OAK_SAPLING),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.OAK_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/oak_sapling"));
         // Dark Oak
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.DARK_OAK_SAPLING),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.DARK_OAK_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/dark_oak_sapling"));
         // Spruce
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.SPRUCE_SAPLING),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.SPRUCE_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/spruce_sapling"));
         // Birch
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.BIRCH_SAPLING),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.BIRCH_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/birch_sapling"));
         // Jungle
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.JUNGLE_SAPLING),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.JUNGLE_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/jungle_sapling"));
         // Acacia
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.ACACIA_SAPLING),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.ACACIA_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/acacia_sapling"));
         // Mangrove
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.MANGROVE_PROPAGULE),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.MANGROVE_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/mangrove_propagule"));
         // Cherry
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.CHERRY_SAPLING),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.CHERRY_LOG, 6),
                 true).build(consumer, Mekmm.rl(basePath + "sapling/cherry_sapling"));
 
@@ -75,123 +81,123 @@ public class PlantingRecipeProvider implements ISubRecipeProvider {
         // 蒲公英
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.DANDELION),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.DANDELION, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/dandelion"));
         // 兰花
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.BLUE_ORCHID),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.BLUE_ORCHID, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/blue_orchid"));
         // 绒球葱
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.ALLIUM),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.ALLIUM, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/allium"));
         // 蓝花美耳草
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.AZURE_BLUET),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.AZURE_BLUET, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/azure_bluet"));
         // 红色郁金香
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.RED_TULIP),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.RED_TULIP, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/red_tulip"));
         // 橙色郁金香
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.ORANGE_TULIP),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.ORANGE_TULIP, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/orange_tulip"));
         // 白色郁金香
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.WHITE_TULIP),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.WHITE_TULIP, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/white_tulip"));
         // 白色郁金香
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.PINK_TULIP),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.PINK_TULIP, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/pink_tulip"));
         // 滨菊
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.OXEYE_DAISY),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.OXEYE_DAISY, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/oxeye_daisy"));
         // 矢车菊
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.CORNFLOWER),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.CORNFLOWER, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/cornflower"));
         // 铃兰
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.LILY_OF_THE_VALLEY),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.LILY_OF_THE_VALLEY, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/lily_of_the_valley"));
         // 凋灵玫瑰
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.WITHER_ROSE),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.WITHER_ROSE, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/wither_rose"));
         // 火把花
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.TORCHFLOWER_SEEDS),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.TORCHFLOWER),
                 true).build(consumer, Mekmm.rl(basePath + "flower/torchflower"));
         // 粉红色花簇
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.PINK_PETALS),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.PINK_PETALS, 3),
                 true).build(consumer, Mekmm.rl(basePath + "flower/pink_petals"));
         // 高花丛
         // 向日葵
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.SUNFLOWER),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.SUNFLOWER, 2),
                 true).build(consumer, Mekmm.rl(basePath + "flower/sunflower"));
         // 丁香
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.LILAC),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.LILAC, 2),
                 true).build(consumer, Mekmm.rl(basePath + "flower/lilac"));
         // 玫瑰从
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.ROSE_BUSH),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.ROSE_BUSH, 2),
                 true).build(consumer, Mekmm.rl(basePath + "flower/rose_bush"));
         // 牡丹
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.PEONY),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.PEONY, 2),
                 true).build(consumer, Mekmm.rl(basePath + "flower/peony"));
         // 瓶子草
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.PITCHER_POD),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.PITCHER_PLANT),
                 true).build(consumer, Mekmm.rl(basePath + "flower/pitcher_plant"));
 
         // Misc
         PlantingStationRecipeBuilder.planting(
                 IngredientCreatorAccess.item().from(Items.MOSS_BLOCK),
-                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(1)),
+                IngredientCreatorAccess.chemicalStack().from(MoreMachineChemicals.NUTRIENT_SOLUTION.asStack(NUTRIENT_COST_PER_TICK)),
                 new ItemStack(Items.MOSS_BLOCK, 4),
                 true).build(consumer, Mekmm.rl(basePath + "flower/moss_block"));
     }

--- a/src/main/java/com/jerry/mekmm/common/tile/machine/TileEntityPlantingStation.java
+++ b/src/main/java/com/jerry/mekmm/common/tile/machine/TileEntityPlantingStation.java
@@ -92,6 +92,13 @@ public class TileEntityPlantingStation extends TileEntityProgressMachine<Plantin
     private final ChemicalUsageMultiplier chemicalUsageMultiplier;
 
     public static final int BASE_TICKS_REQUIRED = 10 * SharedConstants.TICKS_PER_SECOND;
+    /**
+     * Total Nutrient Solution consumed (in mB) per completed recipe operation.
+     * This is intentionally separate from BASE_TICKS_REQUIRED so the chemical
+     * cost can be tuned independently of processing speed.
+     * Lower this value to reduce nutrient solution usage per recipe.
+     */
+    public static final long BASE_CHEMICAL_USAGE = 100;
     public static final long MAX_GAS = 210;
 
     // 化学品存储槽
@@ -142,7 +149,7 @@ public class TileEntityPlantingStation extends TileEntityProgressMachine<Plantin
         chemicalInputHandler = InputHelper.getConstantInputHandler(chemicalTank);
         outputHandler = OutputHelper.getOutputHandler(mainOutputSlot, RecipeError.NOT_ENOUGH_OUTPUT_SPACE, secondaryOutputSlot, NOT_ENOUGH_SPACE_SECONDARY_OUTPUT_ERROR);
 
-        baseTotalUsage = baseTicksRequired;
+        baseTotalUsage = BASE_CHEMICAL_USAGE;
         if (useStatisticalMechanics()) {
             chemicalUsageMultiplier = (usedSoFar, operatingTicks) -> StatUtils.inversePoisson(chemicalPerTickMeanMultiplier);
         } else {
@@ -239,7 +246,7 @@ public class TileEntityPlantingStation extends TileEntityProgressMachine<Plantin
             if (useStatisticalMechanics()) {
                 chemicalPerTickMeanMultiplier = MekanismUtils.getGasPerTickMeanMultiplier(this);
             } else {
-                baseTotalUsage = MekanismUtils.getBaseUsage(this, baseTicksRequired);
+                baseTotalUsage = MekanismUtils.getBaseUsage(this, BASE_CHEMICAL_USAGE);
             }
         }
     }


### PR DESCRIPTION
## What / 目的
This PR decouples the nutrient solution consumption cost from the processing time in planting recipes. Previously, the nutrient cost was hardcoded to match the base ticks required, making it impossible to adjust chemical costs independently of processing speed.

## Implementation Details / 实现细节
Two new constants were introduced to allow independent tuning of nutrient solution costs:

1. **PlantingRecipeProvider.NUTRIENT_COST_PER_TICK**: A recipe-level constant (set to 1 mB) that defines the nutrient solution amount per recipe tick. All 30 planting recipes now reference this constant instead of hardcoded values.

2. **TileEntityPlantingStation.BASE_CHEMICAL_USAGE**: A machine-level constant (set to 100 mB) that defines the total nutrient solution consumed per completed recipe operation. This is intentionally separate from `BASE_TICKS_REQUIRED` to allow independent tuning.

The machine's `baseTotalUsage` is now initialized with `BASE_CHEMICAL_USAGE` instead of `baseTicksRequired`, and upgrade calculations use the new constant as well.

## Outcome / 结果
- Added `NUTRIENT_COST_PER_TICK` constant to PlantingRecipeProvider with documentation
- Added `BASE_CHEMICAL_USAGE` constant to TileEntityPlantingStation with documentation
- Updated all 30 planting recipes to use the new constant instead of hardcoded values
- Updated machine initialization and upgrade calculations to use the new constant
- Nutrient solution costs can now be adjusted independently of processing speed by modifying a single constant

## Potential Compatibility Issues / 潜在兼容性问题
**Recipe Changes**: The nutrient solution amounts in planting recipes remain functionally identical (1 mB per recipe), but are now defined by a constant. Existing recipes will continue to work as before.

**Machine Behavior**: The total nutrient solution consumption per recipe operation remains unchanged (100 mB), but is now controlled by a separate constant from processing time. This allows future balance adjustments without affecting recipe processing speed.