### PR TITLE
[Fixes] 尝试修复部分工厂机器在使用EnderIO时的无法使用导管输入/输出的问题,确保它们能够正常工作. Try to fix the issue of some factories machines not being able to use conduits for input/output when using EnderIO, ensuring that they can work properly.

### DIFF
--- a/src/main/java/com/jerry/mekaf/common/tile/factory/base/TileEntityChemicalToChemicalFactory.java
+++ b/src/main/java/com/jerry/mekaf/common/tile/factory/base/TileEntityChemicalToChemicalFactory.java
@@ -73,6 +73,10 @@ public abstract class TileEntityChemicalToChemicalFactory<RECIPE extends Mekanis
         ConfigInfo chemicalConfig = configComponent.getConfig(TransmissionType.CHEMICAL);
         if (chemicalConfig != null) {
             chemicalConfig.addSlotInfo(DataType.OUTPUT, new ChemicalSlotInfo(false, true, outputChemicalTanks));
+            chemicalConfig.addSlotInfo(DataType.INPUT, new ChemicalSlotInfo(true, false, inputChemicalTanks));
+            List<IChemicalTank> ioTank = new ArrayList<>(inputChemicalTanks);
+            ioTank.addAll(outputChemicalTanks);
+            chemicalConfig.addSlotInfo(DataType.INPUT_OUTPUT, new ChemicalSlotInfo(true, true, ioTank));
         }
         ConfigInfo itemConfig = configComponent.getConfig(TransmissionType.ITEM);
         if (itemConfig != null) {

--- a/src/main/java/com/jerry/mekaf/common/tile/factory/base/TileEntityChemicalToItemFactory.java
+++ b/src/main/java/com/jerry/mekaf/common/tile/factory/base/TileEntityChemicalToItemFactory.java
@@ -83,6 +83,7 @@ public abstract class TileEntityChemicalToItemFactory<RECIPE extends MekanismRec
         ConfigInfo chemicalConfig = configComponent.getConfig(TransmissionType.CHEMICAL);
         if (chemicalConfig != null) {
             chemicalConfig.addSlotInfo(DataType.INPUT, new ChemicalSlotInfo(true, false, inputChemicalTanks));
+            chemicalConfig.addSlotInfo(DataType.INPUT_OUTPUT, new ChemicalSlotInfo(true, true, inputChemicalTanks));
         }
     }
 

--- a/src/main/java/com/jerry/mekaf/common/tile/factory/base/TileEntityItemToChemicalFactory.java
+++ b/src/main/java/com/jerry/mekaf/common/tile/factory/base/TileEntityItemToChemicalFactory.java
@@ -75,6 +75,7 @@ public abstract class TileEntityItemToChemicalFactory<RECIPE extends MekanismRec
         ConfigInfo chemicalConfig = configComponent.getConfig(TransmissionType.CHEMICAL);
         if (chemicalConfig != null) {
             chemicalConfig.addSlotInfo(DataType.OUTPUT, new ChemicalSlotInfo(false, true, outputChemicalTanks));
+            chemicalConfig.addSlotInfo(DataType.INPUT_OUTPUT, new ChemicalSlotInfo(false, true, outputChemicalTanks));
         }
 
         configComponent.setupItemIOConfig(inputItemSlots, Collections.emptyList(), energySlot, false);


### PR DESCRIPTION
## What /目的
尝试修复部分工厂机器在使用EnderIO时无法通过导管进行输入/输出的问题(#171 )，确保它们能够正常工作.

当 EnderIO 导管连接到这些工厂机器时，由于缺少 DataType.INPUT_OUTPUT 的槽位信息配置，EnderIO 的能力系统无法正确识别哪些面支持双向 IO，导致导管无法正常连接或传输流体/化学物质。

## Implementation Details / 实现细节
本 PR 在三个工厂基类的构造函数中新增了 DataType.INPUT_OUTPUT 的化学槽位配置：

1. TileEntityChemicalToChemicalFactory ：将 inputChemicalTanks 和 outputChemicalTanks 合并为一个列表注册到 INPUT_OUTPUT ，允许 EnderIO 导管在任一配置面上同时进行输入和输出操作。
2. TileEntityChemicalToItemFactory ：将 inputChemicalTanks 注册到 INPUT_OUTPUT （该工厂类型仅有化学输入，无化学输出）。
3. TileEntityItemToChemicalFactory ：将 outputChemicalTanks 注册到 INPUT_OUTPUT （该工厂类型仅有化学输出，无化学输入）。
此修改遵循了项目中已有的相同模式（参见 CentrifugingFactory 、 DissolvingFactory 、 WashingFactory 等已有实现），将原本分散在各子类中的 INPUT_OUTPUT 配置 提升至基类统一处理 。

⚠️ 需注意 ：部分子类（ CentrifugingFactory 、 WashingFactory 、 DissolvingFactory ）的构造函数中也存在对相同 DataType 的 addSlotInfo 调用，可能产生重复注册。建议确认 ConfigInfo.addSlotInfo() 的行为（覆盖 vs 追加），并考虑清理子类中的冗余调用以避免潜在问题。

## Outcome / 结果
- 为 ChemicalToChemicalFactory 、 ChemicalToItemFactory 、 ItemToChemicalFactory 三个基类补充了缺失的 DataType.INPUT_OUTPUT 槽位配置
- 使 EnderIO 导管能够正确识别这些工厂机器的 IO 能力，修复导管无法正常连接/传输的问题
- 将 IO 配置逻辑从各子类提升至基类，减少代码重复
## Potential Compatibility Issues / 潜在兼容性问题
- 此更改仅影响侧配置 (side config) 的元数据声明，不涉及 API 变更、物品/方块/配方更改
- 对于 不使用 EnderIO 的环境，此更改应为纯增量添加，不会影响原有功能
- 对于 已使用 EnderIO 的存档，升级后之前无法通过导管连接的工厂机器将变为可用，属于修复性变更