### PR TITLE
Fix large rotary internal tank access

### DIFF
--- a/src/main/java/com/jerry/meklm/common/tile/machine/TileEntityLargeRotaryCondensentrator.java
+++ b/src/main/java/com/jerry/meklm/common/tile/machine/TileEntityLargeRotaryCondensentrator.java
@@ -203,8 +203,8 @@ public class TileEntityLargeRotaryCondensentrator extends TileEntityRecipeMachin
     @Override
     public IContainerHolder<IChemicalTank> getInitialChemicalTanks(IContentsListener listener, IContentsListener recipeCacheListener, IContentsListener recipeCacheUnpauseListener) {
         AdjustableChemicalTankHelper builder = AdjustableChemicalTankHelper.forSide(facingSupplier, side -> side == RelativeSide.BACK, side -> side == RelativeSide.LEFT);
-        builder.addTank(chemicalTank = BasicChemicalTank.create(CAPACITY, (_, automationType) -> automationType == AutomationType.MANUAL || mode,
-                (_, automationType) -> automationType == AutomationType.INTERNAL || !mode, this::isValidChemical, ChemicalAttributeValidator.ALWAYS_ALLOW,
+        builder.addTank(chemicalTank = BasicChemicalTank.create(CAPACITY, (_, automationType) -> !automationType.isExternal() || mode,
+            (_, automationType) -> automationType.isInternal() || !mode, this::isValidChemical, ChemicalAttributeValidator.ALWAYS_ALLOW,
                 recipeCacheListener), RelativeSide.BACK, RelativeSide.LEFT);
         return builder.build();
     }
@@ -217,8 +217,8 @@ public class TileEntityLargeRotaryCondensentrator extends TileEntityRecipeMachin
     @Override
     protected IContainerHolder<IFluidTank> getInitialFluidTanks(IContentsListener listener, IContentsListener recipeCacheListener, IContentsListener recipeCacheUnpauseListener) {
         AdjustableFluidTankHelper builder = AdjustableFluidTankHelper.forSide(facingSupplier, side -> side == RelativeSide.BACK, side -> side == RelativeSide.RIGHT);
-        builder.addTank(fluidTank = BasicFluidTank.create(CAPACITY, (_, automationType) -> automationType == AutomationType.MANUAL || !mode,
-                (_, automationType) -> automationType == AutomationType.INTERNAL || mode, this::isValidFluid, recipeCacheListener), RelativeSide.BACK, RelativeSide.RIGHT);
+        builder.addTank(fluidTank = BasicFluidTank.create(CAPACITY, (_, automationType) -> !automationType.isExternal() || !mode,
+            (_, automationType) -> automationType.isInternal() || mode, this::isValidFluid, recipeCacheListener), RelativeSide.BACK, RelativeSide.RIGHT);
         return builder.build();
     }
 


### PR DESCRIPTION
## What / 目的

修复大型回旋式气液转换机在运行条件均正确时仍无法处理配方的问题。

修复前，即使机器中已有正确的液体或化学品、存在匹配的回旋式气液转换配方、转换模式正确、接口配置正确且能源充足，机器仍可能无法开始或完成转换。

问题的根因是机器的液体罐和化学品罐仍通过直接比较 `AutomationType` 枚举常量来判断内部访问权限。配方处理由 `RotaryCachedRecipe` 通过内部操作读取输入罐并写入输出罐，但原有判断没有正确覆盖 Mekanism 26.1 使用的内部自动化类别，导致有效的配方输入/输出操作被储罐拒绝。

## Implementation Details / 实现细节

更新大型回旋式气液转换机中液体罐和化学品罐的访问权限判断：

- 使用 `automationType.isInternal()` 判断配方系统发起的内部操作；
- 使用 `!automationType.isExternal()` 判断非外部操作；
- 保留原有的模式判断，确保：
  - 液体转化为化学品时，液体罐作为配方输入，化学品罐作为配方输出；
  - 化学品转化为液体时，化学品罐作为配方输入，液体罐作为配方输出；
- 不修改配方查询、能量消耗、端口方向、容量或机器模式逻辑。

该修改允许 `RotaryCachedRecipe` 正常从输入罐提取资源并向输出罐写入转换结果。

## Outcome / 结果

大型回旋式气液转换机现在可以在以下条件均满足时正常执行配方：

- 输入了有效的液体或化学品；
- 存在匹配的回旋式气液转换配方；
- 选择了正确的转换模式；
- 输入和输出接口配置正确；
- 能源供应充足；
- 输出罐具有足够空间。

液体转化为化学品和化学品转化为液体两种模式均可正常进行内部配方输入与输出。

## Additional Information / 附加信息

修改范围仅限于大型回旋式气液转换机的液体罐和化学品罐访问谓词。

验证结果：

- `clean compileJava`：通过
- `spotlessCheck`：通过
- `build`：通过

本 PR 不包含 GUI 或渲染改动，因此无需截图。

## Potential Compatibility Issues / 潜在兼容性问题

无已知兼容性问题。

本 PR 不修改：

- 公开 API；
- 配方内容或配方格式；
- 机器注册信息；
- 液体罐或化学品罐容量；
- 端口位置及方向；
- 能量消耗配置；
- 存档数据格式。